### PR TITLE
Corrigido sessions, ajusta baseUrl e integra Redoc ao Swagger

### DIFF
--- a/src/controllers/SessionController.js
+++ b/src/controllers/SessionController.js
@@ -16,7 +16,7 @@ const state = [
 ];
 
 const index = async (_, res) => {
-  const sessions = fs.readdirSync("sessions");
+  const sessions = fs.readdirSync("data/connections");
   const sessionsList = [];
 
   if (sessions.length > 0) {

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -1,6 +1,5 @@
 const { OpenApiGeneratorV3 } = require('@asteasolutions/zod-to-openapi')
 const registry = require('./registry')
-const {PORT} = require('../utils/Env')
 const {version, description} = require('../../package.json')
 
 const generator = new OpenApiGeneratorV3(registry.definitions)

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -12,7 +12,20 @@ const swaggerSpec = generator.generateDocument({
         version: version,
     },
     servers: [
-        { url: `http://localhost:${PORT}` }
+        { url: '/' }
+    ],
+    externalDocs: {
+        description: 'Abrir no Redoc',
+        url: '/?ui=redoc'
+    },
+    tags: [
+        {
+            name: 'Documentation',
+            externalDocs: {
+                description: 'Abrir no Redoc',
+                url: '/?ui=redoc'
+            }
+        }
     ]
 })
 

--- a/src/routes/sessions.js
+++ b/src/routes/sessions.js
@@ -5,7 +5,6 @@ const validateData = require('../middleware/validateData.js')
 const SessionSchemas = require('../schemas/Controller/sessionSchemas.js')
 const registry = require('../docs/registry.js')
 const { z } = require('../lib/zod.js')
-const {responseContactSchema} = require("../schemas/docs/responseContactSchemas");
 const {responseMessageSchema} = require("../schemas/docs/responseMessage");
 
 const sessionRoutes = Router()
@@ -14,8 +13,8 @@ sessionRoutes.get('/', isAuth, SessionController.index)
 
 registry.registerPath({
     method: 'get',
-    path: '/session',
-    tags: ['Session'],
+    path: '/sessions',
+    tags: ['Sessions'],
     security: [{ bearerAuth: [] }],
     responses: {
         200: {
@@ -43,8 +42,8 @@ sessionRoutes.post(
 
 registry.registerPath({
     method: "post",
-    path: '/session/start',
-    tags: ['Session'],
+    path: '/sessions/start',
+    tags: ['Sessions'],
     security: [{ bearerAuth: [] }],
     request:{
       body:{
@@ -95,8 +94,8 @@ sessionRoutes.post(
 
 registry.registerPath({
     method: "post",
-    path: '/session/add-webhook',
-    tags: ['Session'],
+    path: '/sessions/add-webhook',
+    tags: ['Sessions'],
     security: [{ bearerAuth: [] }],
     request:{
         body:{
@@ -128,8 +127,8 @@ sessionRoutes.delete(
 
 registry.registerPath({
     method: "delete",
-    path: '/session/remove',
-    tags: ['Session'],
+    path: '/sessions/remove',
+    tags: ['Sessions'],
     security: [{ bearerAuth: [] }],
     request:{
         body:{


### PR DESCRIPTION
- Corrige documentação de "session" (singular) para "sessions" (plural)
- Ajusta endpoint GET /sessions que apontava para pasta incorreta
- Atualiza Swagger e Redoc com a nova estrutura
- Adiciona link do Redoc na documentação
- Corrige servers.url para "/" permitindo funcionamento correto atrás de nginx/proxy reverso