### PR TITLE
feat: add optional RabbitMQ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,32 @@ Variáveis de ambiente necessárias:
 - `HOST`: endereço onde a API irá rodar. Padrão: `0.0.0.0`.
 - `PORT`: porta onde a API irá rodar. Padrão: `3300`.
 - `API_KEY`: chave usada para autenticar o acesso aos endpoints.
+- `WEBHOOK`: webhook padrão adicionado como fallback para listeners configurados por sessão.
+- `FROMME`: define se mensagens enviadas pela própria sessão também devem disparar listeners. Use `1` para habilitar.
+- `WA_VERSION`: versão fixa do WhatsApp Web no formato `major,minor,patch`.
+- `WHISPER_PORT`: porta opcional do servidor de transcrição.
+- `WHISPER_MODEL`: modelo opcional usado na transcrição.
+
+### RabbitMQ opcional
+
+A integração com RabbitMQ é opcional. Quando desligada, a API mantém o comportamento atual: envia mensagens e webhooks diretamente.
+
+Quando `RABBITMQ_ENABLED=1`, a API passa a:
+- enfileirar webhooks dos listeners `messaging-history.set`, `messages.upsert` e `messages.update`.
+- enfileirar envios feitos pelo endpoint `POST /messages/:phone`.
+- consumir essas filas no próprio processo da API.
+
+Variáveis adicionais:
+- `RABBITMQ_ENABLED`: habilita o modo com filas. Aceita `1` ou `true`.
+- `RABBITMQ_URL`: URL de conexão com o broker. Obrigatória quando `RABBITMQ_ENABLED=1`.
+- `RABBITMQ_WEBHOOK_QUEUE`: nome da fila de webhooks. Padrão: `whatsapp.webhooks`.
+- `RABBITMQ_OUTBOUND_QUEUE`: nome da fila de mensagens de saída. Padrão: `whatsapp.outbound`.
+- `RABBITMQ_PREFETCH`: quantidade de mensagens consumidas simultaneamente por worker. Padrão: `5`.
+
+Observações operacionais:
+- Se o RabbitMQ estiver habilitado e disponível, o HTTP `200` do endpoint de mensagens confirma que o item foi aceito para processamento, não necessariamente que o WhatsApp já concluiu a entrega.
+- Se o RabbitMQ estiver indisponível no boot ou durante a publicação, a API faz fallback para envio direto para evitar indisponibilidade da operação.
+- O endpoint `/health` continua independente de sessão ativa e do broker.
 
 ## Rotas Disponíveis
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@adiwajshing/keyed-db": "^0.2.4",
     "@asteasolutions/zod-to-openapi": "^8.4.1",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "amqplib": "^0.10.4",
     "axios": "^1.7.8",
     "baileys": "npm:whaileys@6.4.10",
     "better-sqlite3": "^12.6.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "node --watch ./src/server.js",
     "start": "node ./src/server.js",
-    "lint": "eslint --ext .js src --fix"
+    "lint": "eslint --ext .js src --fix",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/src/controllers/MessageController.js
+++ b/src/controllers/MessageController.js
@@ -30,7 +30,7 @@ const sendTextMedia = async (req, res) => {
     if (sentMessage)
       res.status(200).json({ message: 'Mensagem enviada com sucesso' })
   } catch (error) {
-    res.status(400).json({ message: 'Erro ao enviar mensagem de midia' })
+    res.status(400).json({ message: 'Erro ao enviar mensagem de mídia' })
   }
 }
 

--- a/src/controllers/MessageController.js
+++ b/src/controllers/MessageController.js
@@ -1,7 +1,7 @@
 const {
   prepareMediaMessageContent,
 } = require('../lib/helpers/prepareMediaMessageContent.js')
-const sendMessage = require('../lib/helpers/sendMessage.js')
+const { enqueueOutboundMessage } = require('../lib/queue/rabbitmq.js')
 const GetAllUnreadMessages = require('../lib/helpers/unreadMessages')
 
 const sendTextMedia = async (req, res) => {
@@ -21,7 +21,7 @@ const sendTextMedia = async (req, res) => {
       content = { text: message }
     }
 
-    const sentMessage = await sendMessage({
+    const sentMessage = await enqueueOutboundMessage({
       phone,
       number,
       content,
@@ -30,7 +30,7 @@ const sendTextMedia = async (req, res) => {
     if (sentMessage)
       res.status(200).json({ message: 'Mensagem enviada com sucesso' })
   } catch (error) {
-    res.status(400).json({ message: 'Erro ao enviar mensagem de mídia' })
+    res.status(400).json({ message: 'Erro ao enviar mensagem de midia' })
   }
 }
 

--- a/src/lib/listeners.js
+++ b/src/lib/listeners.js
@@ -1,26 +1,22 @@
-const axios = require('axios')
 const fetchWebHook = require('../utils/fetchWebHook.js')
 const logger = require('../utils/logger.js')
 const prepareMessageData = require('./handlers/prepareMessageData.js')
 const isValidMsg = require('./helpers/isValidMessage.js')
 const env = require('../utils/Env.js')
-const {readFileSync, writeFileSync} = require("fs");
+const { enqueueWebhookDelivery } = require('./queue/rabbitmq.js')
+const { readFileSync, writeFileSync } = require('fs')
 const slugfy = require('../utils/slugfy.js')
 
 const sendWebhook = async (webhookUrl, data) => {
   try {
-    await axios.post(webhookUrl, data, {
-      headers: {
-        'api-token': env.API_KEY,
-      },
-    })
+    await enqueueWebhookDelivery({ webhookUrl, data })
   } catch (error) {
     logger.error(error)
   }
 }
 
 const baileysMessageListeners = (wbot, phone) => {
-  logger.info(`Iniciando sessão ${phone}`)
+  logger.info(`Iniciando sessao ${phone}`)
 
   wbot.ev.on('messaging-history.set', async (data) => {
     const chatsNaoLidos = []
@@ -41,7 +37,7 @@ const baileysMessageListeners = (wbot, phone) => {
               conversa &&
               conversa.messages.length < (chat.unreadCount || 0)
             ) {
-              conversas?.find((t) => t.key === chat.id)?.messages.push(message)
+              conversas.find((t) => t.key === chat.id)?.messages.push(message)
             }
           }
         }
@@ -111,45 +107,43 @@ const baileysMessageListeners = (wbot, phone) => {
         })
       }
     }
-  });
+  })
 
-  wbot.ev.on("contacts.upsert", async (contacts) => {
+  wbot.ev.on('contacts.upsert', async (contacts) => {
     let contactsJSONExists
     try {
-      contactsJSONExists = readFileSync(
-          `data/sessions/${slugfy(wbot.phone)}.json`
-      );
+      contactsJSONExists = readFileSync(`data/sessions/${slugfy(wbot.phone)}.json`)
     } catch (error) {
-      contactsJSONExists = null;
+      contactsJSONExists = null
     }
 
     if (contactsJSONExists) {
-      let convertFileJSON = JSON.parse(contactsJSONExists.toString());
+      let convertFileJSON = JSON.parse(contactsJSONExists.toString())
 
       if (
-          contacts &&
-          typeof convertFileJSON === "object" &&
-          convertFileJSON.length > 0
+        contacts &&
+        typeof convertFileJSON === 'object' &&
+        convertFileJSON.length > 0
       ) {
         for await (const contact of contacts) {
           convertFileJSON = convertFileJSON.filter(
-              (value) => value.id !== contact.id
-          );
-          convertFileJSON.push(contact);
+            (value) => value.id !== contact.id,
+          )
+          convertFileJSON.push(contact)
         }
       }
 
       return writeFileSync(
-          `data/sessions/${slugfy(wbot.phone)}.json`,
-          JSON.stringify(convertFileJSON)
-      );
+        `data/sessions/${slugfy(wbot.phone)}.json`,
+        JSON.stringify(convertFileJSON),
+      )
     }
 
     return writeFileSync(
-        `data/sessions/${slugfy(wbot.phone)}.json`,
-        JSON.stringify(contacts)
-    );
-  });
+      `data/sessions/${slugfy(wbot.phone)}.json`,
+      JSON.stringify(contacts),
+    )
+  })
 }
 
 module.exports = { baileysMessageListeners, sendWebhook }

--- a/src/lib/queue/rabbitmq.js
+++ b/src/lib/queue/rabbitmq.js
@@ -198,10 +198,14 @@ const enqueueOutboundMessage = async ({ phone, number, content }) => {
 }
 
 const closeRabbitMQ = async () => {
-  if (!connection) return
-
   shuttingDown = true
   clearReconnectTimeout()
+
+  if (!connection) {
+    resetState()
+    shuttingDown = false
+    return
+  }
 
   try {
     await connection.close()

--- a/src/lib/queue/rabbitmq.js
+++ b/src/lib/queue/rabbitmq.js
@@ -4,17 +4,40 @@ const logger = require('../../utils/logger.js')
 const env = require('../../utils/Env.js')
 const sendMessage = require('../helpers/sendMessage.js')
 
+const RECONNECT_DELAY_MS = 5000
+
 let connection = null
 let channel = null
 let initializingPromise = null
 let consumersStarted = false
 let shuttingDown = false
+let reconnectTimeout = null
 
 const isRabbitMQEnabled = () => env.RABBITMQ_ENABLED && !!env.RABBITMQ_URL
 
 const assertQueues = async (targetChannel) => {
   await targetChannel.assertQueue(env.RABBITMQ_WEBHOOK_QUEUE, { durable: true })
   await targetChannel.assertQueue(env.RABBITMQ_OUTBOUND_QUEUE, { durable: true })
+}
+
+const clearReconnectTimeout = () => {
+  if (!reconnectTimeout) return
+
+  clearTimeout(reconnectTimeout)
+  reconnectTimeout = null
+}
+
+const scheduleReconnect = () => {
+  if (!isRabbitMQEnabled() || shuttingDown || reconnectTimeout) return
+
+  reconnectTimeout = setTimeout(() => {
+    reconnectTimeout = null
+    void initRabbitMQ()
+  }, RECONNECT_DELAY_MS)
+
+  logger.warn(
+    `Nova tentativa de conexao com RabbitMQ agendada para ${RECONNECT_DELAY_MS / 1000}s.`,
+  )
 }
 
 const resetState = () => {
@@ -82,7 +105,7 @@ const startConsumers = async (targetChannel) => {
   consumersStarted = true
 }
 
-const initRabbitMQ = async () => {
+async function initRabbitMQ() {
   if (!isRabbitMQEnabled()) return null
   if (channel) return channel
   if (initializingPromise) return initializingPromise
@@ -101,14 +124,16 @@ const initRabbitMQ = async () => {
 
         if (!shuttingDown) {
           logger.warn(
-            'Conexao RabbitMQ encerrada. A API continuara com fallback para envio direto.',
+            'Conexao RabbitMQ encerrada. A API continuara com fallback para envio direto ate religar o broker.',
           )
+          scheduleReconnect()
         }
       })
 
       await assertQueues(nextChannel)
       await startConsumers(nextChannel)
 
+      clearReconnectTimeout()
       connection = nextConnection
       channel = nextChannel
 
@@ -118,6 +143,7 @@ const initRabbitMQ = async () => {
     } catch (error) {
       resetState()
       logger.error(`Nao foi possivel conectar ao RabbitMQ: ${error.message}`)
+      scheduleReconnect()
       return null
     } finally {
       initializingPromise = null
@@ -175,6 +201,7 @@ const closeRabbitMQ = async () => {
   if (!connection) return
 
   shuttingDown = true
+  clearReconnectTimeout()
 
   try {
     await connection.close()

--- a/src/lib/queue/rabbitmq.js
+++ b/src/lib/queue/rabbitmq.js
@@ -1,0 +1,195 @@
+const amqp = require('amqplib')
+const axios = require('axios')
+const logger = require('../../utils/logger.js')
+const env = require('../../utils/Env.js')
+const sendMessage = require('../helpers/sendMessage.js')
+
+let connection = null
+let channel = null
+let initializingPromise = null
+let consumersStarted = false
+let shuttingDown = false
+
+const isRabbitMQEnabled = () => env.RABBITMQ_ENABLED && !!env.RABBITMQ_URL
+
+const assertQueues = async (targetChannel) => {
+  await targetChannel.assertQueue(env.RABBITMQ_WEBHOOK_QUEUE, { durable: true })
+  await targetChannel.assertQueue(env.RABBITMQ_OUTBOUND_QUEUE, { durable: true })
+}
+
+const resetState = () => {
+  channel = null
+  connection = null
+  consumersStarted = false
+}
+
+const deliverWebhook = async ({ webhookUrl, data }) => {
+  await axios.post(webhookUrl, data, {
+    headers: {
+      'api-token': env.API_KEY,
+    },
+  })
+}
+
+const deliverOutboundMessage = async ({ phone, number, content }) => {
+  await sendMessage({ phone, number, content })
+  return true
+}
+
+const startConsumers = async (targetChannel) => {
+  if (consumersStarted) return
+
+  await targetChannel.prefetch(env.RABBITMQ_PREFETCH)
+
+  await targetChannel.consume(
+    env.RABBITMQ_WEBHOOK_QUEUE,
+    async (message) => {
+      if (!message) return
+
+      try {
+        const payload = JSON.parse(message.content.toString())
+        await deliverWebhook(payload)
+        targetChannel.ack(message)
+      } catch (error) {
+        logger.error(
+          `Erro ao processar webhook da fila ${env.RABBITMQ_WEBHOOK_QUEUE}: ${error.message}`,
+        )
+        targetChannel.nack(message, false, false)
+      }
+    },
+    { noAck: false },
+  )
+
+  await targetChannel.consume(
+    env.RABBITMQ_OUTBOUND_QUEUE,
+    async (message) => {
+      if (!message) return
+
+      try {
+        const payload = JSON.parse(message.content.toString())
+        await deliverOutboundMessage(payload)
+        targetChannel.ack(message)
+      } catch (error) {
+        logger.error(
+          `Erro ao processar envio da fila ${env.RABBITMQ_OUTBOUND_QUEUE}: ${error.message}`,
+        )
+        targetChannel.nack(message, false, false)
+      }
+    },
+    { noAck: false },
+  )
+
+  consumersStarted = true
+}
+
+const initRabbitMQ = async () => {
+  if (!isRabbitMQEnabled()) return null
+  if (channel) return channel
+  if (initializingPromise) return initializingPromise
+
+  initializingPromise = (async () => {
+    try {
+      const nextConnection = await amqp.connect(env.RABBITMQ_URL)
+      const nextChannel = await nextConnection.createChannel()
+
+      nextConnection.on('error', (error) => {
+        logger.error(`Erro de conexao com RabbitMQ: ${error.message}`)
+      })
+
+      nextConnection.on('close', () => {
+        resetState()
+
+        if (!shuttingDown) {
+          logger.warn(
+            'Conexao RabbitMQ encerrada. A API continuara com fallback para envio direto.',
+          )
+        }
+      })
+
+      await assertQueues(nextChannel)
+      await startConsumers(nextChannel)
+
+      connection = nextConnection
+      channel = nextChannel
+
+      logger.info('RabbitMQ conectado. Filas de webhooks e mensagens habilitadas.')
+
+      return channel
+    } catch (error) {
+      resetState()
+      logger.error(`Nao foi possivel conectar ao RabbitMQ: ${error.message}`)
+      return null
+    } finally {
+      initializingPromise = null
+    }
+  })()
+
+  return initializingPromise
+}
+
+const publishJob = async ({ queueName, payload, fallback, description }) => {
+  if (!isRabbitMQEnabled()) {
+    return fallback(payload)
+  }
+
+  try {
+    const targetChannel = await initRabbitMQ()
+
+    if (!targetChannel) {
+      logger.warn(`RabbitMQ indisponivel. ${description} sera processado diretamente.`)
+      return fallback(payload)
+    }
+
+    targetChannel.sendToQueue(queueName, Buffer.from(JSON.stringify(payload)), {
+      persistent: true,
+    })
+
+    return true
+  } catch (error) {
+    logger.error(
+      `Erro ao publicar ${description} na fila ${queueName}: ${error.message}`,
+    )
+    return fallback(payload)
+  }
+}
+
+const enqueueWebhookDelivery = async ({ webhookUrl, data }) => {
+  return publishJob({
+    queueName: env.RABBITMQ_WEBHOOK_QUEUE,
+    payload: { webhookUrl, data },
+    fallback: deliverWebhook,
+    description: 'o webhook',
+  })
+}
+
+const enqueueOutboundMessage = async ({ phone, number, content }) => {
+  return publishJob({
+    queueName: env.RABBITMQ_OUTBOUND_QUEUE,
+    payload: { phone, number, content },
+    fallback: deliverOutboundMessage,
+    description: 'o envio de mensagem',
+  })
+}
+
+const closeRabbitMQ = async () => {
+  if (!connection) return
+
+  shuttingDown = true
+
+  try {
+    await connection.close()
+  } catch (error) {
+    logger.error(`Erro ao encerrar conexao RabbitMQ: ${error.message}`)
+  } finally {
+    resetState()
+    shuttingDown = false
+  }
+}
+
+module.exports = {
+  closeRabbitMQ,
+  enqueueOutboundMessage,
+  enqueueWebhookDelivery,
+  initRabbitMQ,
+  isRabbitMQEnabled,
+}

--- a/src/lib/queue/rabbitmq.js
+++ b/src/lib/queue/rabbitmq.js
@@ -5,6 +5,7 @@ const env = require('../../utils/Env.js')
 const sendMessage = require('../helpers/sendMessage.js')
 
 const RECONNECT_DELAY_MS = 5000
+const BUFFER_MARKER = '__queueBuffer'
 
 let connection = null
 let channel = null
@@ -14,6 +15,54 @@ let shuttingDown = false
 let reconnectTimeout = null
 
 const isRabbitMQEnabled = () => env.RABBITMQ_ENABLED && !!env.RABBITMQ_URL
+
+const isPlainObject = (value) =>
+  Object.prototype.toString.call(value) === '[object Object]'
+
+const serializePayloadForQueue = (value) => {
+  if (Buffer.isBuffer(value)) {
+    return { [BUFFER_MARKER]: value.toString('base64') }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(serializePayloadForQueue)
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        serializePayloadForQueue(nestedValue),
+      ]),
+    )
+  }
+
+  return value
+}
+
+const deserializePayloadFromQueue = (value) => {
+  if (Array.isArray(value)) {
+    return value.map(deserializePayloadFromQueue)
+  }
+
+  if (isPlainObject(value)) {
+    if (
+      Object.keys(value).length === 1 &&
+      typeof value[BUFFER_MARKER] === 'string'
+    ) {
+      return Buffer.from(value[BUFFER_MARKER], 'base64')
+    }
+
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        deserializePayloadFromQueue(nestedValue),
+      ]),
+    )
+  }
+
+  return value
+}
 
 const assertQueues = async (targetChannel) => {
   await targetChannel.assertQueue(env.RABBITMQ_WEBHOOK_QUEUE, { durable: true })
@@ -70,7 +119,9 @@ const startConsumers = async (targetChannel) => {
       if (!message) return
 
       try {
-        const payload = JSON.parse(message.content.toString())
+        const payload = deserializePayloadFromQueue(
+          JSON.parse(message.content.toString()),
+        )
         await deliverWebhook(payload)
         targetChannel.ack(message)
       } catch (error) {
@@ -89,7 +140,9 @@ const startConsumers = async (targetChannel) => {
       if (!message) return
 
       try {
-        const payload = JSON.parse(message.content.toString())
+        const payload = deserializePayloadFromQueue(
+          JSON.parse(message.content.toString()),
+        )
         await deliverOutboundMessage(payload)
         targetChannel.ack(message)
       } catch (error) {
@@ -166,9 +219,13 @@ const publishJob = async ({ queueName, payload, fallback, description }) => {
       return fallback(payload)
     }
 
-    targetChannel.sendToQueue(queueName, Buffer.from(JSON.stringify(payload)), {
-      persistent: true,
-    })
+    targetChannel.sendToQueue(
+      queueName,
+      Buffer.from(JSON.stringify(serializePayloadForQueue(payload))),
+      {
+        persistent: true,
+      },
+    )
 
     return true
   } catch (error) {
@@ -219,8 +276,10 @@ const closeRabbitMQ = async () => {
 
 module.exports = {
   closeRabbitMQ,
+  deserializePayloadFromQueue,
   enqueueOutboundMessage,
   enqueueWebhookDelivery,
   initRabbitMQ,
   isRabbitMQEnabled,
+  serializePayloadForQueue,
 }

--- a/src/lib/queue/rabbitmq.test.js
+++ b/src/lib/queue/rabbitmq.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  deserializePayloadFromQueue,
+  serializePayloadForQueue,
+} = require('./rabbitmq.js')
+
+test('preserves media buffers across queue serialization', () => {
+  const originalPayload = {
+    phone: '5511999999999',
+    number: '5511888888888',
+    content: {
+      caption: 'arquivo',
+      image: Buffer.from('fake-image'),
+      audio: Buffer.from([1, 2, 3, 4]),
+      nested: {
+        document: Buffer.from('fake-doc'),
+      },
+      items: [Buffer.from('thumb')],
+    },
+  }
+
+  const restoredPayload = deserializePayloadFromQueue(
+    JSON.parse(JSON.stringify(serializePayloadForQueue(originalPayload))),
+  )
+
+  assert.deepStrictEqual(restoredPayload, originalPayload)
+  assert.equal(Buffer.isBuffer(restoredPayload.content.image), true)
+  assert.equal(Buffer.isBuffer(restoredPayload.content.audio), true)
+  assert.equal(Buffer.isBuffer(restoredPayload.content.nested.document), true)
+  assert.equal(Buffer.isBuffer(restoredPayload.content.items[0]), true)
+})
+
+test('keeps regular webhook payload data intact', () => {
+  const originalPayload = {
+    webhookUrl: 'https://example.com/hook',
+    data: {
+      action: 'receiveMessage',
+      message: JSON.stringify({ text: 'hello' }),
+      file: JSON.stringify({ name: 'test.txt' }),
+    },
+  }
+
+  const restoredPayload = deserializePayloadFromQueue(
+    JSON.parse(JSON.stringify(serializePayloadForQueue(originalPayload))),
+  )
+
+  assert.deepStrictEqual(restoredPayload, originalPayload)
+})

--- a/src/routes/messages.js
+++ b/src/routes/messages.js
@@ -3,8 +3,10 @@ const MessageController = require('../controllers/MessageController.js')
 const isAuth = require('../middleware/isAuth.js')
 const validateData = require('../middleware/validateData.js')
 const MessageSchemas = require('../schemas/Controller/messageSchemas.js')
-const {prepareMessageResponseSchema} = require('../schemas/docs/preparemessageSchemas.js')
-const {responseMessageSchema} = require('../schemas/docs/responseMessage.js')
+const {
+  prepareMessageResponseSchema,
+} = require('../schemas/docs/preparemessageSchemas.js')
+const { responseMessageSchema } = require('../schemas/docs/responseMessage.js')
 const registry = require('../docs/registry.js')
 const { z } = require('../lib/zod.js')
 
@@ -18,39 +20,49 @@ messageRoutes.post(
 )
 
 registry.registerPath({
-    method: 'post',
-    path: '/messages/{phone}',
-    tags: ['Messages'],
-    security: [{ bearerAuth: [] }],
-    request: {
-        params: z.object({
-            phone: z.string().openapi({ example: '5599999999999' })
-        }),
-        body: {
-            content: {
-                'application/json': {
-                    schema: MessageSchemas.sendTextSchema
-                },
-                'multipart/form-data': {
-                    schema: MessageSchemas.sendMediaSchema
-                }
-            }
-        }
-    },
-    responses: {
-        200: {
-            description: 'Mensagem enviada com sucesso',
-            content: {
-                'application/json': { schema: responseMessageSchema.openapi({ example: { message: 'Mensagem enviada com sucesso' } }) }
-            }
+  method: 'post',
+  path: '/messages/{phone}',
+  tags: ['Messages'],
+  description:
+    'Envia a mensagem imediatamente ou a enfileira quando o RabbitMQ estiver habilitado.',
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: z.object({
+      phone: z.string().openapi({ example: '5599999999999' }),
+    }),
+    body: {
+      content: {
+        'application/json': {
+          schema: MessageSchemas.sendTextSchema,
         },
-        400: {
-            description: 'Erro ao enviar mensagem de mídia',
-            content: {
-                'application/json': { schema: responseMessageSchema.openapi({ example: { message: 'Erro ao enviar mensagem de mídia' } }) }
-            }
-        }
-    }
+        'multipart/form-data': {
+          schema: MessageSchemas.sendMediaSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Mensagem enviada com sucesso ou enfileirada para envio',
+      content: {
+        'application/json': {
+          schema: responseMessageSchema.openapi({
+            example: { message: 'Mensagem enviada com sucesso' },
+          }),
+        },
+      },
+    },
+    400: {
+      description: 'Erro ao enviar mensagem de mídia',
+      content: {
+        'application/json': {
+          schema: responseMessageSchema.openapi({
+            example: { message: 'Erro ao enviar mensagem de mídia' },
+          }),
+        },
+      },
+    },
+  },
 })
 registry.register('sendTextSchema', MessageSchemas.sendTextSchema)
 registry.register('sendMediaSchema', MessageSchemas.sendMediaSchema)
@@ -58,31 +70,35 @@ registry.register('sendMediaSchema', MessageSchemas.sendMediaSchema)
 messageRoutes.get('/:phone/unread', isAuth, MessageController.unreadMessages)
 
 registry.registerPath({
-    method: 'get',
-    path: '/messages/{phone}/unread',
-    tags: ['Messages'],
-    security: [{ bearerAuth: [] }],
-    request: {
-        params: z.object({
-            phone: z.string().openapi({ example: '5599999999999' })
-        })
-    },
-    responses: {
-        200: {
-            description: 'Lista de mensagens não lidas',
-            content: {
-                'application/json': {
-                    schema: z.array(prepareMessageResponseSchema)
-                }
-            }
+  method: 'get',
+  path: '/messages/{phone}/unread',
+  tags: ['Messages'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: z.object({
+      phone: z.string().openapi({ example: '5599999999999' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Lista de mensagens não lidas',
+      content: {
+        'application/json': {
+          schema: z.array(prepareMessageResponseSchema),
         },
-        400: {
-            description: 'Erro ao obter mensagens',
-            content: {
-                'application/json': { schema: responseMessageSchema.openapi({ example: { message: 'Erro ao obter mensagens' } }) }
-            }
-        }
-    }
+      },
+    },
+    400: {
+      description: 'Erro ao obter mensagens',
+      content: {
+        'application/json': {
+          schema: responseMessageSchema.openapi({
+            example: { message: 'Erro ao obter mensagens' },
+          }),
+        },
+      },
+    },
+  },
 })
 
 module.exports = messageRoutes

--- a/src/server.js
+++ b/src/server.js
@@ -2,11 +2,15 @@ const express = require('express')
 const fileUpload = require('express-fileupload')
 const fs = require('fs')
 const { initBaileysSocket } = require('./lib/libbaileys.js')
+const { initRabbitMQ, closeRabbitMQ } = require('./lib/queue/rabbitmq.js')
 const routes = require('./routes/index.js')
 const logger = require('./utils/logger.js')
 const cors = require('cors')
 const env = require('./utils/Env.js')
-const { startWhisperServer, stopWhisperServer } = require('./lib/helpers/whisperServer.js')
+const {
+  startWhisperServer,
+  stopWhisperServer,
+} = require('./lib/helpers/whisperServer.js')
 
 process.on('uncaughtException', (err) => {
   logger.error(`Uncaught Exception: ${err.message}`)
@@ -54,6 +58,7 @@ const port = env.PORT || 9000
 
 const server = app.listen(port, '127.0.0.1', async () => {
   logger.info(`Servidor iniciado na porta ${port}`)
+  await initRabbitMQ()
   await restoreSessions()
   await startWhisperServer()
 })
@@ -76,20 +81,20 @@ async function restoreSessions() {
           const sessionData = JSON.parse(fileContent)
 
           if (sessionData.phone) {
-            logger.info(`Restaurando sessão: ${sessionData.phone}`)
+            logger.info(`Restaurando sessao: ${sessionData.phone}`)
             await initBaileysSocket(sessionData.phone)
             contador++
-            await new Promise(resolve => setTimeout(resolve, 500))
+            await new Promise((resolve) => setTimeout(resolve, 500))
           }
         } catch (err) {
-          logger.error(`Erro ao restaurar sessão ${session}: ${err.message}`)
+          logger.error(`Erro ao restaurar sessao ${session}: ${err.message}`)
         }
       }
     }
 
-    logger.info(`Restauração de sessões concluída. Total de ${contador} sessões iniciadas.`)
+    logger.info(`Restauracao de sessoes concluida. Total de ${contador} sessoes iniciadas.`)
   } catch (error) {
-    logger.error(`Erro fatal na restauração de sessões: ${error.message}`)
+    logger.error(`Erro fatal na restauracao de sessoes: ${error.message}`)
   }
 }
 
@@ -98,12 +103,14 @@ function gracefulShutdown(signal) {
 
   server.close(async () => {
     logger.info('Servidor HTTP fechado.')
+    await closeRabbitMQ()
     await stopWhisperServer()
     process.exit(0)
   })
 
   setTimeout(async () => {
-    logger.error('Forçando encerramento.')
+    logger.error('Forcando encerramento.')
+    await closeRabbitMQ()
     await stopWhisperServer()
     process.exit(1)
   }, 10000)

--- a/src/utils/Env.js
+++ b/src/utils/Env.js
@@ -11,6 +11,20 @@ const ValidaNumeros = z.string().refine(
   { message: 'Numero Invalido' },
 )
 
+const ValidaNumeroOpcional = z
+  .string()
+  .optional()
+  .default('5')
+  .transform((v) => {
+    const numero = Number(v)
+
+    if (isNaN(numero) || v?.length === 0) {
+      throw new Error('Numero Invalido')
+    }
+
+    return numero
+  })
+
 const ValidaWaVersion = z
   .string()
   .optional()
@@ -57,11 +71,7 @@ const envSchema = z.object({
   RABBITMQ_URL: z.string().optional(),
   RABBITMQ_WEBHOOK_QUEUE: z.string().optional().default('whatsapp.webhooks'),
   RABBITMQ_OUTBOUND_QUEUE: z.string().optional().default('whatsapp.outbound'),
-  RABBITMQ_PREFETCH: z
-    .string()
-    .optional()
-    .default('5')
-    .transform((v) => Number(v)),
+  RABBITMQ_PREFETCH: ValidaNumeroOpcional,
 })
 
 const env = envSchema.parse(process.env)

--- a/src/utils/Env.js
+++ b/src/utils/Env.js
@@ -21,7 +21,7 @@ const ValidaWaVersion = z
 
     if (parts.length !== 3) {
       throw new Error(
-        'WA_VERSION deve ter 3 números separados por vírgula (ex: 2,3000,1023223821)',
+        'WA_VERSION deve ter 3 numeros separados por virgula (ex: 2,3000,1023223821)',
       )
     }
 
@@ -29,7 +29,7 @@ const ValidaWaVersion = z
       const num = Number(p)
       if (isNaN(num)) {
         throw new Error(
-          `WA_VERSION contém valor inválido: "${p}". Use apenas números.`,
+          `WA_VERSION contem valor invalido: "${p}". Use apenas numeros.`,
         )
       }
       return num
@@ -38,15 +38,36 @@ const ValidaWaVersion = z
     return version
   })
 
+const ValidaBoolean = z
+  .string()
+  .optional()
+  .default('0')
+  .transform((v) => ['1', 'true'].includes(v.toLowerCase()))
+
 const envSchema = z.object({
   HOST: z.string().ipv4().default('0.0.0.0'),
   PORT: ValidaNumeros,
   FROMME: z.string().transform((v) => v === '1'),
   API_KEY: z.string().min(10, 'Chave muito pequena'),
-  WEBHOOK: z.string().min(10, 'Verifique o endereço do Webhook Padrão'),
+  WEBHOOK: z.string().min(10, 'Verifique o endereco do Webhook Padrao'),
   WA_VERSION: ValidaWaVersion,
   WHISPER_PORT: z.string().optional(),
   WHISPER_MODEL: z.string().optional(),
+  RABBITMQ_ENABLED: ValidaBoolean,
+  RABBITMQ_URL: z.string().optional(),
+  RABBITMQ_WEBHOOK_QUEUE: z.string().optional().default('whatsapp.webhooks'),
+  RABBITMQ_OUTBOUND_QUEUE: z.string().optional().default('whatsapp.outbound'),
+  RABBITMQ_PREFETCH: z
+    .string()
+    .optional()
+    .default('5')
+    .transform((v) => Number(v)),
 })
 
-module.exports = envSchema.parse(process.env)
+const env = envSchema.parse(process.env)
+
+if (env.RABBITMQ_ENABLED && !env.RABBITMQ_URL) {
+  throw new Error('RABBITMQ_URL deve ser informado quando RABBITMQ_ENABLED=1')
+}
+
+module.exports = env


### PR DESCRIPTION
## Summary
- add an optional RabbitMQ layer for outbound WhatsApp messages and webhook deliveries
- keep direct processing as the default behavior and fallback path when the broker is unavailable
- document the new environment variables and queued delivery semantics in README and OpenAPI

## Testing
- not run in this environment

## Notes
- when `RABBITMQ_ENABLED=1`, `POST /messages/:phone` keeps returning HTTP 200 after the job is accepted for processing
- webhook and outbound queues are consumed by the API process itself

Closes #3